### PR TITLE
[add]: add basedOnDependencyAnalysis setting

### DIFF
--- a/Mongle/Tuist/ProjectDescriptionHelpers/Scripts.swift
+++ b/Mongle/Tuist/ProjectDescriptionHelpers/Scripts.swift
@@ -23,6 +23,7 @@ public extension TargetScript {
             echo "warning: SwiftLint configuration file ($SWIFTLINT_CONFIG) not found"
         fi
         """,
-        name: "SwiftLintString"
+        name: "SwiftLintString",
+        basedOnDependencyAnalysis: false
     )
 }


### PR DESCRIPTION
## 🎫 지라 티켓 이슈
- DMVM-95

<br>

## 🛠️ 작업 내용
<!-- 작업 내용 (스크린샷도 같이 있으면 좋아요) -->
> ⚠️Warning
Run script build phase 'SwiftLintString' will be run during every build because it does not specify any outputs. To address this warning, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase.

경고가 발생하여 해결 하기 위해  `basedOnDependencyAnalysis: false`를 추가하였습니다.
<br>

