### PR TITLE
[design]: create profile view Ui

### DIFF
--- a/Mongle/Projects/Core/Sources/Dummy.swift
+++ b/Mongle/Projects/Core/Sources/Dummy.swift
@@ -1,9 +1,0 @@
-//
-//  Dummy.swift
-//  Core
-//
-//  Created by bulmang on 4/9/24.
-//  Copyright © 2024 Mongle-iOS. All rights reserved.
-//
-
-import Foundation

--- a/Mongle/Projects/Core/Sources/FetchImage.swift
+++ b/Mongle/Projects/Core/Sources/FetchImage.swift
@@ -1,0 +1,40 @@
+//
+//  FetchImage.swift
+//  Core
+//
+//  Created by bulmang on 4/20/24.
+//  Copyright © 2024 Mongle-iOS. All rights reserved.
+//
+
+import Foundation
+
+struct DogImageResponse: Codable {
+    let message: String
+    let status: String
+}
+
+public func fetchDogImage(completion: @escaping (String?) -> Void) {
+    guard let url = URL(string: "https://dog.ceo/api/breeds/image/random") else {
+        completion(nil)
+        return
+    }
+    
+    URLSession.shared.dataTask(with: url) { data, response, error in
+        guard let data = data, error == nil else {
+            print("Failed to fetch data: \(error?.localizedDescription ?? "Unknown error")")
+            completion(nil)
+            return
+        }
+        
+        if let decodedResponse = try? JSONDecoder().decode(DogImageResponse.self, from: data) {
+            DispatchQueue.main.async {
+                completion(decodedResponse.message)
+            }
+        } else {
+            print("Failed to decode JSON")
+            completion(nil)
+        }
+    }.resume()
+}
+
+

--- a/Mongle/Projects/Features/ProfileFeature/Demo/Sources/ProfileFeatureDemoApp.swift
+++ b/Mongle/Projects/Features/ProfileFeature/Demo/Sources/ProfileFeatureDemoApp.swift
@@ -7,12 +7,13 @@
 //
 
 import SwiftUI
+import ProfileFeature
 
 @main
 struct ProfileFeatureDemoApp: App {
     var body: some Scene {
         WindowGroup {
-            Text("ProfileFeatureDemoApp")
+            ProfileView()
         }
     }
 }

--- a/Mongle/Projects/Features/ProfileFeature/Demo/Sources/ProfileFeatureDemoApp.swift
+++ b/Mongle/Projects/Features/ProfileFeature/Demo/Sources/ProfileFeatureDemoApp.swift
@@ -1,0 +1,19 @@
+//
+//  ProfileFeatureDemoApp.swift
+//  ProfileFeatureDemo
+//
+//  Created by bulmang on 4/20/24.
+//  Copyright © 2024 Mongle-iOS. All rights reserved.
+//
+
+import SwiftUI
+
+@main
+struct ProfileFeatureDemoApp: App {
+    var body: some Scene {
+        WindowGroup {
+            Text("ProfileFeatureDemoApp")
+        }
+    }
+}
+

--- a/Mongle/Projects/Features/ProfileFeature/Sources/Dummy.swift
+++ b/Mongle/Projects/Features/ProfileFeature/Sources/Dummy.swift
@@ -1,9 +1,0 @@
-//
-//  Dummy.swift
-//  Core
-//
-//  Created by bulmang on 4/9/24.
-//  Copyright © 2024 Mongle-iOS. All rights reserved.
-//
-
-import Foundation

--- a/Mongle/Projects/Features/ProfileFeature/Sources/FavoriteStoreArea.swift
+++ b/Mongle/Projects/Features/ProfileFeature/Sources/FavoriteStoreArea.swift
@@ -1,0 +1,63 @@
+//
+//  FavoriteStoreArea.swift
+//  ProfileFeature
+//
+//  Created by bulmang on 4/20/24.
+//  Copyright © 2024 Mongle-iOS. All rights reserved.
+//
+
+import Core
+import SwiftUI
+import Ui
+
+struct FavoriteStoreArea: View {
+    @State private var dogImageUrl: String?
+    
+    var body: some View {
+        VStack(spacing: 16) {
+            HStack(spacing: 6) {
+                Text("찜한 업체")
+                    .font(.mgTitle1)
+                    .foregroundStyle(.black)
+                
+                Text("4")
+                    .font(.mgTitle3)
+                    .foregroundStyle(Color.mongleGrayScale500)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            
+            ScrollView(.horizontal) {
+                VStack(spacing: 8) {
+                    if let imageUrl = dogImageUrl {
+                        AsyncImage(url: URL(string: imageUrl)) { image in
+                            image.resizable()
+                        } placeholder: {
+                            ProgressView()
+                        }
+                        .frame(width: 100, height: 100)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                    } else {
+                        ProgressView()
+                            .frame(width: 100, height: 100)
+                    }
+                    
+                    Text("개신남 3호점")
+                        .font(.mgTitle3)
+                        .foregroundStyle(.black)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .onAppear {
+            fetchDogImage { imageUrl in
+                DispatchQueue.main.async {
+                    self.dogImageUrl = imageUrl
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    FavoriteStoreArea()
+}

--- a/Mongle/Projects/Features/ProfileFeature/Sources/PersonProfileArea.swift
+++ b/Mongle/Projects/Features/ProfileFeature/Sources/PersonProfileArea.swift
@@ -1,0 +1,60 @@
+//
+//  PersonProfileArea.swift
+//  ProfileFeature
+//
+//  Created by bulmang on 4/20/24.
+//  Copyright © 2024 Mongle-iOS. All rights reserved.
+//
+
+import Core
+import SwiftUI
+import Ui
+
+struct PersonProfileArea: View {
+    @State private var dogImageUrl: String?
+    
+    var body: some View {
+        HStack(spacing: 16) {
+            if let imageUrl = dogImageUrl {
+                AsyncImage(url: URL(string: imageUrl)) { image in
+                    image.resizable()
+                } placeholder: {
+                    ProgressView()
+                }
+                .frame(width: 68, height: 68)
+                .clipShape(Circle())
+            } else {
+                ProgressView()
+                    .frame(width: 68, height: 68)
+            }
+            
+            VStack(alignment: .leading, spacing: 4) {
+                
+                iconHorizontalButton("몽글몽글", buttonColor: Color.clear, textColor: Color.black, textFont: .mgTitle1, verticalPadding: 4, horizontalPadding: 0, radius: 0, iconImage: Image.chevronRightIcon, spacing: 6, iconLeft: false) {
+                }
+                
+                
+                Text("양천구 목동")
+                    .font(.mgBody4)
+                    .foregroundStyle(Color.mongleGrayScale800)
+                
+                Text("010-1234-1234")
+                    .font(.mgBody4)
+                    .foregroundStyle(Color.mongleGrayScale800)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.top, 20)
+        .onAppear {
+            fetchDogImage { imageUrl in
+                DispatchQueue.main.async {
+                    self.dogImageUrl = imageUrl
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    PersonProfileArea()
+}

--- a/Mongle/Projects/Features/ProfileFeature/Sources/PetList.swift
+++ b/Mongle/Projects/Features/ProfileFeature/Sources/PetList.swift
@@ -1,0 +1,93 @@
+//
+//  PetList.swift
+//  ProfileFeature
+//
+//  Created by bulmang on 4/20/24.
+//  Copyright © 2024 Mongle-iOS. All rights reserved.
+//
+
+import Core
+import SwiftUI
+import Ui
+
+struct PetList: View {
+    @State private var dogImageUrl: String?
+    
+    var body: some View {
+        HStack(alignment: .top, spacing: 15) {
+            if let imageUrl = dogImageUrl {
+                AsyncImage(url: URL(string: imageUrl)) { image in
+                    image.resizable()
+                } placeholder: {
+                    ProgressView()
+                }
+                .frame(width: 68, height: 68)
+                .clipShape(Circle())
+            } else {
+                ProgressView()
+                    .frame(width: 68, height: 68)
+            }
+            
+            VStack(spacing: 8) {
+                HStack(spacing: 6) {
+                    Text("김뽀삐")
+                        .font(.mgTitle1)
+                        .foregroundStyle(Color.black)
+                    
+                    Text("♀")
+                        .font(.mgTitle3)
+                        .foregroundStyle(Color.mongleGrayScale400)
+                    
+                    Spacer()
+                    
+                    Button {
+                        
+                    } label: {
+                        Image.pencilIcon
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                
+                HStack(spacing: 3) {
+                    Text("시그로자브종")
+                        .font(.mgBody4)
+                        .foregroundStyle(Color.mongleGrayScale800)
+                    
+                    Text("|")
+                        .font(.mgBody4)
+                        .foregroundStyle(Color.mongleGrayScale300)
+                    
+                    Text("3년 4개월")
+                        .font(.mgBody4)
+                        .foregroundStyle(Color.mongleGrayScale800)
+                    
+                    Text("|")
+                        .font(.mgBody4)
+                        .foregroundStyle(Color.mongleGrayScale300)
+                    
+                    Text("3kg")
+                        .font(.mgBody4)
+                        .foregroundStyle(Color.mongleGrayScale800)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .padding(16)
+        .background {
+            RoundedRectangle(cornerRadius: 8)
+                .foregroundStyle(Color.mongleGrayScale100)
+                .frame(maxWidth: .infinity)
+        }
+        .onAppear {
+            fetchDogImage { imageUrl in
+                DispatchQueue.main.async {
+                    self.dogImageUrl = imageUrl
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    PetList()
+}

--- a/Mongle/Projects/Features/ProfileFeature/Sources/PetProfileArea.swift
+++ b/Mongle/Projects/Features/ProfileFeature/Sources/PetProfileArea.swift
@@ -1,0 +1,43 @@
+//
+//  PetProfileArea.swift
+//  ProfileFeature
+//
+//  Created by bulmang on 4/20/24.
+//  Copyright © 2024 Mongle-iOS. All rights reserved.
+//
+
+import SwiftUI
+import Ui
+
+struct PetProfileArea: View {
+    var body: some View {
+        VStack(spacing: 16) {
+            HStack(spacing: 6) {
+                Text("반려 동물")
+                    .font(.mgTitle1)
+                    .foregroundStyle(.black)
+                
+                Text("2")
+                    .font(.mgTitle3)
+                    .foregroundStyle(Color.mongleGrayScale500)
+                
+                Spacer()
+                
+                Button {
+                    
+                } label: {
+                    Image.plucIcon
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            
+            PetList()
+            
+            PetList()
+        }
+    }
+}
+
+#Preview {
+    PetProfileArea()
+}

--- a/Mongle/Projects/Features/ProfileFeature/Sources/ProfileView.swift
+++ b/Mongle/Projects/Features/ProfileFeature/Sources/ProfileView.swift
@@ -1,0 +1,33 @@
+//
+//  ProfileView.swift
+//  ProfileFeature
+//
+//  Created by bulmang on 4/20/24.
+//  Copyright © 2024 Mongle-iOS. All rights reserved.
+//
+
+import SwiftUI
+import Ui
+
+struct ProfileView: View {
+    var body: some View {
+        VStack(spacing: 0) {
+            TabHeaderComponent(headerText: "마이", iconImageName: Image.gearIcon) { }
+            
+            VStack(spacing: 32) {
+                PersonProfileArea()
+                
+                PetProfileArea()
+                
+                FavoriteStoreArea()
+            }
+            Spacer()
+            
+        }
+        .padding(.horizontal, 20)
+    }
+}
+
+#Preview {
+    ProfileView()
+}

--- a/Mongle/Projects/Features/ProfileFeature/Sources/ProfileView.swift
+++ b/Mongle/Projects/Features/ProfileFeature/Sources/ProfileView.swift
@@ -9,8 +9,10 @@
 import SwiftUI
 import Ui
 
-struct ProfileView: View {
-    var body: some View {
+public struct ProfileView: View {
+    public init() {}
+    
+    public var body: some View {
         VStack(spacing: 0) {
             TabHeaderComponent(headerText: "마이", iconImageName: Image.gearIcon) { }
             

--- a/Mongle/Projects/Ui/Sources/DesignSystem/ImageExtension.swift
+++ b/Mongle/Projects/Ui/Sources/DesignSystem/ImageExtension.swift
@@ -19,4 +19,7 @@ public extension Image {
     static let searchIcon = UiAsset.Images.searchIcon.swiftUIImage
     static let chevronRightIcon = UiAsset.Images.chevronRightIcon.swiftUIImage
     static let markerPinIcon = UiAsset.Images.markerPinIcon.swiftUIImage
+    static let gearIcon = UiAsset.Images.gearIcon.swiftUIImage
+    static let plucIcon = UiAsset.Images.plucIcon.swiftUIImage
+    static let pencilIcon = UiAsset.Images.pencilIcon.swiftUIImage
 }


### PR DESCRIPTION
## 🎫 지라 티켓 이슈
- DMVM-103
<br>

<br>

## 🛠️ 작업 내용
<!-- 작업 내용 (스크린샷도 같이 있으면 좋아요) -->
MongleApp의 Profile Lo-Fi 디자인 부분 작업을 하였습니다.
Core에서 함수를 구현하여 dog api를 사용해서 랜덤 이미지를 가져와서 표시합니다.
추후 server api와 연결하여 고객 이미지와 정보들을 표시합니다.

### ProfileView
`TabHeaderComponent, PersonProfileArea, PetProfileArea, FavoriteStoreArea`로 구성되어 있습니다.
- **`TabHeaderComponent`**
  - Profile의 Header 부분입니다.
  - Component를 사용하여 표시합니다.
- **`PersonProfileArea`**
  - 고객 정보를 표시합니다.
- **`PetProfileArea`**
  - 반려동물 정보를 표시합니다.
  - `PetList`를 사용해서 등록한 여러 반려견의 정보를 표시합니다.
- **`FavoriteStoreArea`**
  - 찜한 목욕업체를 표시합니다..
  - `PetList`를 사용해서 등록한 여러 반려견의 정보를 표시합니다.


<br>

<br>

## 📱 작업 화면
<!-- img src "이부분에 gif파일 넣어주시면 됩니다" -->
|화면 이름|스크린샷|
|:--:|:--:|
| ProfileView |<img src = "https://github.com/PBTP/Mongle_iOS/assets/114594496/b2da6a47-2265-409e-946f-43cdd4cb9b48" width ="250">|

<br>

## 🗒️ Note (optional)
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
