### PR TITLE
DMVM-141(feature): feat apple auth core

### DIFF
--- a/Mongle/Projects/App/App.entitlements
+++ b/Mongle/Projects/App/App.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/Mongle/Projects/App/AppDebug.entitlements
+++ b/Mongle/Projects/App/AppDebug.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/Mongle/Projects/App/Sources/MainApp.swift
+++ b/Mongle/Projects/App/Sources/MainApp.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2024 Mongle-iOS. All rights reserved.
 //
 
+import Core
 import SwiftUI
 import KakaoSDKCommon
 import KakaoSDKAuth
@@ -13,6 +14,8 @@ import OnBoardingFeature
 
 @main
 struct Mongle: App {
+    @StateObject var kakaoAuth = KaKaoAuthCore()
+    
     init() {
         if let appKey = ProcessInfo.processInfo.environment["KAKAO_APP_KEY"] {
             KakaoSDK.initSDK(appKey: appKey)
@@ -22,6 +25,7 @@ struct Mongle: App {
     var body: some Scene {
         WindowGroup {
             LoginView()
+                .environmentObject(kakaoAuth)
         }
     }
 }

--- a/Mongle/Projects/Core/Sources/Authentication/AppleAuthCore.swift
+++ b/Mongle/Projects/Core/Sources/Authentication/AppleAuthCore.swift
@@ -15,40 +15,46 @@ public struct AppleAuthCore {
     
     @ObservableState
     public struct State: Equatable {
-        public var userIdentifier: String?
-        public var fullName: String?
-        public var name: String?
-        public var email: String?
-        public var identityToken: String?
-        public var authorizationCode: String?
-
-        public init() {}
+        public var customer: Customer
+        
+        public init() {
+            self.customer = Customer()
+        }
     }
     
     public enum Action {
+        case appleButtonTapped(ASAuthorizationAppleIDCredential)
         case login(ASAuthorizationAppleIDCredential)
-        case loginInfoPrint
+        case loginError(Error)
     }
     
     public var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
             case let .login(credentials):
-                state.userIdentifier = credentials.user
-                state.fullName = (credentials.fullName?.familyName ?? "") + (credentials.fullName?.givenName ?? "")
-                state.email = credentials.email?.debugDescription ?? ""
-                state.identityToken = String(data: credentials.identityToken!, encoding: .utf8) ?? ""
-                state.authorizationCode = String(data: credentials.authorizationCode!, encoding: .utf8) ?? ""
-                print("state: \(state)")
-                    
+                state.customer.uuid = credentials.user
+                
+                if let familyName = credentials.fullName?.familyName, let givenName = credentials.fullName?.givenName {
+                    state.customer.customerName = familyName + givenName
+                } else {
+                    state.customer.customerName = nil
+                }
+                
+                state.customer.authProvider = "APPLE"
+                
+                NetworkManager.shared.sendUserData(customer: state.customer)
+                
                 return .none
                 
-            case .loginInfoPrint:
-                print("user identifier: \(String(describing: state.userIdentifier ?? nil))")
-                print("user identityToken: \(String(describing: state.identityToken ?? nil))")
-                print("user fullName: \(String(describing: state.fullName ?? nil))")
-                print("email: \(String(describing: state.email ?? nil))")
-                print("authorizationCode: \(String(describing: state.authorizationCode ?? nil))")
+            case let .appleButtonTapped(credientials):
+                return .run { send in
+                    await send(.login(credientials))
+                } catch: { error, send in
+                    await send(.loginError(error))
+                }
+                
+            case let .loginError(error):
+                print(error)
                 return .none
             }
         }

--- a/Mongle/Projects/Core/Sources/Authentication/AppleAuthCore.swift
+++ b/Mongle/Projects/Core/Sources/Authentication/AppleAuthCore.swift
@@ -1,0 +1,56 @@
+//
+//  AppleAuthCore.swift
+//  Core
+//
+//  Created by bulmang on 5/15/24.
+//  Copyright © 2024 Mongle-iOS. All rights reserved.
+//
+
+import AuthenticationServices
+import ComposableArchitecture
+
+@Reducer
+public struct AppleAuthCore {
+    public init() {}
+    
+    @ObservableState
+    public struct State: Equatable {
+        public var userIdentifier: String = ""
+        public var fullName: String = ""
+        public var name: String = ""
+        public var email: String = ""
+        public var identityToken: String = ""
+        public var authorizationCode: String = ""
+
+        public init() {}
+    }
+    
+    public enum Action {
+        case login(ASAuthorizationAppleIDCredential)
+        case loginInfoPrint
+    }
+    
+    public var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case let .login(credentials):
+                state.userIdentifier = credentials.user
+                state.fullName = (credentials.fullName?.familyName ?? "") + (credentials.fullName?.givenName ?? "")
+                state.email = credentials.email?.debugDescription ?? ""
+                state.identityToken = String(data: credentials.identityToken!, encoding: .utf8) ?? ""
+                state.authorizationCode = String(data: credentials.authorizationCode!, encoding: .utf8) ?? ""
+                print("state: \(state)")
+                    
+                return .none
+                
+            case .loginInfoPrint:
+                print("user identifier: \(state.userIdentifier)")
+                print("user identityToken: \(state.identityToken)")
+                print("user fullName: \(state.fullName)")
+                print("email: \(state.email)")
+                print("authorizationCode: \(state.authorizationCode)")
+                return .none
+            }
+        }
+    }
+}

--- a/Mongle/Projects/Core/Sources/Authentication/AppleAuthCore.swift
+++ b/Mongle/Projects/Core/Sources/Authentication/AppleAuthCore.swift
@@ -15,12 +15,12 @@ public struct AppleAuthCore {
     
     @ObservableState
     public struct State: Equatable {
-        public var userIdentifier: String = ""
-        public var fullName: String = ""
-        public var name: String = ""
-        public var email: String = ""
-        public var identityToken: String = ""
-        public var authorizationCode: String = ""
+        public var userIdentifier: String?
+        public var fullName: String?
+        public var name: String?
+        public var email: String?
+        public var identityToken: String?
+        public var authorizationCode: String?
 
         public init() {}
     }
@@ -44,11 +44,11 @@ public struct AppleAuthCore {
                 return .none
                 
             case .loginInfoPrint:
-                print("user identifier: \(state.userIdentifier)")
-                print("user identityToken: \(state.identityToken)")
-                print("user fullName: \(state.fullName)")
-                print("email: \(state.email)")
-                print("authorizationCode: \(state.authorizationCode)")
+                print("user identifier: \(String(describing: state.userIdentifier ?? nil))")
+                print("user identityToken: \(String(describing: state.identityToken ?? nil))")
+                print("user fullName: \(String(describing: state.fullName ?? nil))")
+                print("email: \(String(describing: state.email ?? nil))")
+                print("authorizationCode: \(String(describing: state.authorizationCode ?? nil))")
                 return .none
             }
         }

--- a/Mongle/Projects/Core/Sources/Authentication/KaKaoAuthCore.swift
+++ b/Mongle/Projects/Core/Sources/Authentication/KaKaoAuthCore.swift
@@ -1,139 +1,72 @@
 //
-//  AuthenticationReducer.swift
+//  kakaoAuth.swift
 //  Core
 //
-//  Created by bulmang on 5/12/24.
+//  Created by bulmang on 6/12/24.
 //  Copyright © 2024 Mongle-iOS. All rights reserved.
 //
 
-import ComposableArchitecture
-import KakaoSDKAuth
+import Foundation
 import KakaoSDKUser
-import KakaoSDKCommon
 
-@Reducer
-public struct KaKaoAuthCore {
-    public init() {}
+public class KaKaoAuthCore: ObservableObject {
+    @Published public var customer: Customer
     
-    @ObservableState
-    public struct State: Equatable {
-        public var kakaoToken: String = ""
-        
-        public init() {}
+    public init() {
+        self.customer = Customer()
     }
     
-    public enum Action {
-        case loginKakaoAccount
-        case logoutKakaoAccount
-        case hasToken
-        case getTokenInfo
-        case getUserInfo
-        case unLinkKakaoAccount
-    }
-    
-    public var body: some Reducer<State, Action> {
-        Reduce { state, action in
-            switch action {
-                
-            case .loginKakaoAccount:
-                if UserApi.isKakaoTalkLoginAvailable() {
-                    UserApi.shared.loginWithKakaoTalk {(oauthToken, error) in
-                        if let error = error {
-                            print(error)
-                        }
-                        else {
-                            print("loginWithKakaoTalk() success.")
-                            
-                            //do something
-                            _ = oauthToken
-                        }
-                    }
-                } else {
-                    UserApi.shared.loginWithKakaoAccount {(oauthToken, error) in
-                        if let error = error {
-                            print(error)
-                        }
-                        else {
-                            print("loginWithKakaoAccount() success.")
-                            
-                            //do something
-                            _ = oauthToken
-                        }
-                    }
-                }
-                return .none
-                
-            case .logoutKakaoAccount:
-                UserApi.shared.logout {(error) in
-                    if let error = error {
-                        print(error)
-                    }
-                    else {
-                        print("logout() success.")
-                    }
-                }
-                return .none
-                
-            case .hasToken:
-                if AuthApi.hasToken() {
-                    UserApi.shared.accessTokenInfo { (_, error) in
-                        if let error = error {
-                            if let sdkError = error as? SdkError, sdkError.isInvalidTokenError() == true  {
-                                print("로그인 필요")
-                            }
-                            else {
-                                print(error)
-                            }
-                        }
-                        else {
-                            print("토큰 유효성 체크 성공(필요 시 토큰 갱신됨)")
-                        }
-                    }
+    public func loginKakaoAccount() {
+        if UserApi.isKakaoTalkLoginAvailable() {
+            UserApi.shared.loginWithKakaoTalk {(oauthToken, error) in
+                if let error = error {
+                    print(error)
                 }
                 else {
-                    print("로그인 필요")
+                    print("loginWithKakaoTalk() success.")
+                    
+                    self.getUserInfo()
                 }
-                return .none
+            }
+        } else {
+            UserApi.shared.loginWithKakaoAccount {(oauthToken, error) in
+                if let error = error {
+                    print(error)
+                }
+                else {
+                    print("loginWithKakaoAccount() success.")
+                    
+                    self.getUserInfo()
+                }
+            }
+        }
+    }
+    
+    private func getUserInfo() {
+        UserApi.shared.me() { [weak self] (user, error) in
+            if let error = error {
+                print(error)
+            } else {
+                print("me() success.")
+                guard let self = self else { return }
                 
-            case .getTokenInfo:
-                print("getTokenInfo() called")
-                UserApi.shared.accessTokenInfo {(accessTokenInfo, error) in
-                    if let error = error {
-                        print(error)
-                    }
-                    else {
-                        print("accessTokenInfo() success.")
-                        
-                        //do something
-                        _ = accessTokenInfo
-                    }
+                if let uuid = user?.id?.description {
+                    self.customer.uuid = uuid
                 }
-                return .none
                 
-            case .getUserInfo:
-                UserApi.shared.me() {(user, error) in
-                    if let error = error {
-                        print(error)
-                    }
-                    else {
-                        print("me() success.")
-                        
-                        //do something
-                        _ = user
-                    }
+                if let customerName = user?.kakaoAccount?.profile?.nickname {
+                    self.customer.customerName = customerName
                 }
-                return .none
                 
-            case .unLinkKakaoAccount:
-                UserApi.shared.unlink {(error) in
-                    if let error = error {
-                        print(error)
-                    }
-                    else {
-                        print("unlink() success.")
-                    }
+                if let customerPhoneNumber = user?.kakaoAccount?.phoneNumber {
+                    self.customer.customerPhoneNumber = customerPhoneNumber
                 }
-                return .none
+                
+                self.customer.authProvider = "KAKAO"
+                
+                print(self.customer)
+                
+                NetworkManager.shared.sendUserData(customer: customer)
             }
         }
     }

--- a/Mongle/Projects/Core/Sources/Authentication/KaKaoAuthCore.swift
+++ b/Mongle/Projects/Core/Sources/Authentication/KaKaoAuthCore.swift
@@ -58,10 +58,6 @@ public class KaKaoAuthCore: ObservableObject {
                     self.customer.customerName = customerName
                 }
                 
-                if let customerPhoneNumber = user?.kakaoAccount?.phoneNumber {
-                    self.customer.customerPhoneNumber = customerPhoneNumber
-                }
-                
                 self.customer.authProvider = "KAKAO"
                 
                 print(self.customer)

--- a/Mongle/Projects/Core/Sources/JsonDecode/JsonDecoder.swift
+++ b/Mongle/Projects/Core/Sources/JsonDecode/JsonDecoder.swift
@@ -1,0 +1,27 @@
+//
+//  JsonDecoder.swift
+//  Core
+//
+//  Created by bulmang on 6/19/24.
+//  Copyright © 2024 Mongle-iOS. All rights reserved.
+//
+
+import Foundation
+
+class JsonDecoder {
+    static let shared = JsonDecoder()
+    
+    private init() {}
+    
+    func decodeCustomer(from jsonString: String) -> Customer? {
+        let jsonData = jsonString.data(using: .utf8)!
+        
+        do {
+            let customer = try JSONDecoder().decode(Customer.self, from: jsonData)
+            return customer
+        } catch {
+            print("Error decoding JSON: \(error)")
+            return nil
+        }
+    }
+}

--- a/Mongle/Projects/Core/Sources/Model/Customer.swift
+++ b/Mongle/Projects/Core/Sources/Model/Customer.swift
@@ -9,27 +9,21 @@
 import Foundation
 
 public struct Customer: Codable, Equatable {
-    var customerId: String?
     var uuid: String?
     var customerName: String?
-    var customerPhoneNumber: String?
     var authProvider: String?
     var accessToken: String?
     var refreshToken: String?
     
     public init(
-        customerId: String? = nil,
         uuid: String? = nil,
         customerName: String? = nil,
-        customerPhoneNumber: String? = nil,
         authProvider: String? = nil,
         accessToken: String? = nil,
         refreshToken: String? = nil
     ) {
-        self.customerId = customerId
         self.uuid = uuid
         self.customerName = customerName
-        self.customerPhoneNumber = customerPhoneNumber
         self.authProvider = authProvider
         self.accessToken = accessToken
         self.refreshToken = refreshToken

--- a/Mongle/Projects/Core/Sources/Model/Customer.swift
+++ b/Mongle/Projects/Core/Sources/Model/Customer.swift
@@ -1,0 +1,37 @@
+//
+//  Customer.swift
+//  Core
+//
+//  Created by bulmang on 6/12/24.
+//  Copyright © 2024 Mongle-iOS. All rights reserved.
+//
+
+import Foundation
+
+public struct Customer: Codable, Equatable {
+    var customerId: String?
+    var uuid: String?
+    var customerName: String?
+    var customerPhoneNumber: String?
+    var authProvider: String?
+    var accessToken: String?
+    var refreshToken: String?
+    
+    public init(
+        customerId: String? = nil,
+        uuid: String? = nil,
+        customerName: String? = nil,
+        customerPhoneNumber: String? = nil,
+        authProvider: String? = nil,
+        accessToken: String? = nil,
+        refreshToken: String? = nil
+    ) {
+        self.customerId = customerId
+        self.uuid = uuid
+        self.customerName = customerName
+        self.customerPhoneNumber = customerPhoneNumber
+        self.authProvider = authProvider
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+    }
+}

--- a/Mongle/Projects/Core/Sources/NetworkManager/NetworkManager.swift
+++ b/Mongle/Projects/Core/Sources/NetworkManager/NetworkManager.swift
@@ -44,6 +44,16 @@ class NetworkManager {
                     
                     if let data = data, let responseString = String(data: data, encoding: .utf8) {
                         print("Response Data: \(responseString)")
+                        
+                        if let customer = JsonDecoder.shared.decodeCustomer(from: responseString) {
+                            print("Customer UUID: \(customer.uuid ?? "nil")")
+                            print("Customer Name: \(customer.customerName ?? "nil")")
+                            print("Auth Provider: \(customer.authProvider ?? "nil")")
+                            print("Access Token: \(customer.accessToken ?? "nil")")
+                            print("Refresh Token: \(customer.refreshToken ?? "nil")")
+                        } else {
+                            print("Failed to decode customer")
+                        }
                     }
                     
                     if (200...299).contains(httpResponse.statusCode) {

--- a/Mongle/Projects/Core/Sources/NetworkManager/NetworkManager.swift
+++ b/Mongle/Projects/Core/Sources/NetworkManager/NetworkManager.swift
@@ -1,0 +1,61 @@
+//
+//  NetworkManager.swift
+//  Core
+//
+//  Created by bulmang on 6/19/24.
+//  Copyright © 2024 Mongle-iOS. All rights reserved.
+//
+
+import Foundation
+
+class NetworkManager {
+    static let shared = NetworkManager()
+    
+    private init() {}
+    
+    func sendUserData(customer: Customer) {
+        guard let url = URL(string: "https://api.mgmg.life/v1/auth/login") else {
+            print("Error creating URL")
+            return
+        }
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        
+        let userData: [String: String?] = [
+            "uuid": customer.uuid,
+            "customerName": customer.customerName ?? nil,
+            "authProvider": customer.authProvider ?? nil,
+        ]
+        
+        do {
+            let jsonData = try JSONSerialization.data(withJSONObject: userData, options: [])
+            request.httpBody = jsonData
+            
+            let task = URLSession.shared.dataTask(with: request) { data, response, error in
+                if let error = error {
+                    print("Error sending user data: \(error)")
+                    return
+                }
+                
+                if let httpResponse = response as? HTTPURLResponse {
+                    print("HTTP Response Status Code: \(httpResponse.statusCode)")
+                    
+                    if let data = data, let responseString = String(data: data, encoding: .utf8) {
+                        print("Response Data: \(responseString)")
+                    }
+                    
+                    if (200...299).contains(httpResponse.statusCode) {
+                        print("User data sent successfully")
+                    } else {
+                        print("Failed to send user data")
+                    }
+                }
+            }
+            task.resume()
+        } catch {
+            print("Error creating JSON data: \(error)")
+        }
+    }
+}

--- a/Mongle/Projects/Features/OnBoardingFeature/Sources/Features/OnBoardingReducer.swift
+++ b/Mongle/Projects/Features/OnBoardingFeature/Sources/Features/OnBoardingReducer.swift
@@ -12,7 +12,7 @@ import ComposableArchitecture
 @Reducer(state: .equatable)
 public enum OnBoardingReducer {
     case agree(AgreeStore)
-    case authentication(KaKaoAuthCore)
+    case kakaoAuthentication(KaKaoAuthCore)
     
     public static var body: some ReducerOf<Self> {
         Reduce { state, action in
@@ -20,16 +20,21 @@ public enum OnBoardingReducer {
             case .agree:
                 state = .agree(AgreeStore.State())
                 return .none
-            case .authentication:
-                state = .authentication(KaKaoAuthCore.State())
+            case .kakaoAuthentication:
+                state = .kakaoAuthentication(KaKaoAuthCore.State())
                 return .none
             }
         }
         .ifCaseLet(\.agree, action: \.agree) {
             AgreeStore()
         }
-        .ifCaseLet(\.authentication, action: \.authentication) {
+        .ifCaseLet(\.kakaoAuthentication, action: \.kakaoAuthentication) {
             KaKaoAuthCore()
         }
     }
+}
+
+public enum OnBoardingAction {
+    case agree(AgreeStore.Action)
+    case kakaoAuthentication(KaKaoAuthCore.Action)
 }

--- a/Mongle/Projects/Features/OnBoardingFeature/Sources/Features/OnBoardingReducer.swift
+++ b/Mongle/Projects/Features/OnBoardingFeature/Sources/Features/OnBoardingReducer.swift
@@ -12,7 +12,6 @@ import ComposableArchitecture
 @Reducer(state: .equatable)
 public enum OnBoardingReducer {
     case agree(AgreeStore)
-    case kakaoAuthentication(KaKaoAuthCore)
     
     public static var body: some ReducerOf<Self> {
         Reduce { state, action in
@@ -20,21 +19,14 @@ public enum OnBoardingReducer {
             case .agree:
                 state = .agree(AgreeStore.State())
                 return .none
-            case .kakaoAuthentication:
-                state = .kakaoAuthentication(KaKaoAuthCore.State())
-                return .none
             }
         }
         .ifCaseLet(\.agree, action: \.agree) {
             AgreeStore()
-        }
-        .ifCaseLet(\.kakaoAuthentication, action: \.kakaoAuthentication) {
-            KaKaoAuthCore()
         }
     }
 }
 
 public enum OnBoardingAction {
     case agree(AgreeStore.Action)
-    case kakaoAuthentication(KaKaoAuthCore.Action)
 }

--- a/Mongle/Projects/Features/OnBoardingFeature/Sources/Views/LoginView.swift
+++ b/Mongle/Projects/Features/OnBoardingFeature/Sources/Views/LoginView.swift
@@ -6,7 +6,9 @@
 //  Copyright © 2024 Mongle-iOS. All rights reserved.
 //
 
+import AuthenticationServices
 import ComposableArchitecture
+import Core
 import SwiftUI
 import Ui
 import KakaoSDKCommon
@@ -16,37 +18,72 @@ import KakaoSDKUser
 public struct LoginView: View {
     public init() {
         if let appKey = ProcessInfo.processInfo.environment["KAKAO_APP_KEY"] {
-                  KakaoSDK.initSDK(appKey: appKey)
         }
     }
     
-    let store = Store(initialState: OnBoardingReducer.State.authentication(.init())) {
+    let store = Store(initialState: OnBoardingReducer.State.kakaoAuthentication(.init())) {
         OnBoardingReducer.body._printChanges()
     }
     
     public var body: some View {
         
-            VStack(spacing: 12) {
-                HeaderComponent(headerText: "로그인", iconImageName: Image.xCloseIcon) {}
-                
-                Spacer()
-                
-                KaKaoLoginButton {
-                    store.send(.authentication(.loginKakaoAccount))
-                }
-                
-                AppleLoginButton {}
-                
-                SkipLoginButton {}
+        VStack(spacing: 12) {
+            HeaderComponent(headerText: "로그인", iconImageName: Image.xCloseIcon) {}
+            
+            Spacer()
+            
+            KaKaoLoginButton {
+                store.send(.kakaoAuthentication(.loginKakaoAccount))
+            }
+            
+            AppleSigninButton()
+            
+            SkipLoginButton {}
                 .padding(.top, 24)
                 .padding(.bottom, 50)
+        }
+        .padding(.horizontal, 20)
+        .onOpenURL(perform: { url in
+            if (AuthApi.isKakaoTalkLoginUrl(url)) {
+                _ = AuthController.handleOpenUrl(url: url)
             }
-            .padding(.horizontal, 20)
-            .onOpenURL(perform: { url in
-                if (AuthApi.isKakaoTalkLoginUrl(url)) {
-                    _ = AuthController.handleOpenUrl(url: url)
+        })
+    }
+}
+
+struct AppleSigninButton : View {
+    let store = Store(initialState: AppleAuthCore.State()) {
+        AppleAuthCore().body._printChanges()
+    }
+    
+    var body: some View{
+        VStack {
+            SignInWithAppleButton(
+                .continue,
+                onRequest: { request in
+                    request.requestedScopes = [.fullName, .email]
+                },
+                onCompletion: { result in
+                    switch result {
+                    case .success(let authResults):
+                        print("Apple Login Successful")
+                        switch authResults.credential{
+                        case let appleIDCredential as ASAuthorizationAppleIDCredential:
+                            store.send(.login(appleIDCredential))
+                            
+                        default:
+                            break
+                        }
+                    case .failure(let error):
+                        print(error.localizedDescription)
+                        print("error")
+                    }
                 }
-            })
+            )
+            .frame(maxWidth: .infinity)
+            .frame(height:46)
+            .cornerRadius(8)
+        }
     }
 }
 

--- a/Mongle/Projects/Features/OnBoardingFeature/Sources/Views/LoginView.swift
+++ b/Mongle/Projects/Features/OnBoardingFeature/Sources/Views/LoginView.swift
@@ -16,13 +16,11 @@ import KakaoSDKAuth
 import KakaoSDKUser
 
 public struct LoginView: View {
+    @EnvironmentObject var kakaoAuth: KaKaoAuthCore
+    
     public init() {
         if let appKey = ProcessInfo.processInfo.environment["KAKAO_APP_KEY"] {
         }
-    }
-    
-    let store = Store(initialState: OnBoardingReducer.State.kakaoAuthentication(.init())) {
-        OnBoardingReducer.body._printChanges()
     }
     
     public var body: some View {
@@ -33,7 +31,7 @@ public struct LoginView: View {
             Spacer()
             
             KaKaoLoginButton {
-                store.send(.kakaoAuthentication(.loginKakaoAccount))
+                kakaoAuth.loginKakaoAccount()
             }
             
             AppleSigninButton()
@@ -69,7 +67,7 @@ struct AppleSigninButton : View {
                         print("Apple Login Successful")
                         switch authResults.credential{
                         case let appleIDCredential as ASAuthorizationAppleIDCredential:
-                            store.send(.login(appleIDCredential))
+                            store.send(.appleButtonTapped(appleIDCredential))
                             
                         default:
                             break

--- a/Mongle/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Mongle/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -46,6 +46,7 @@ public extension Project {
         if targets.contains(.app) {
             let bundleSuffix = "demo"
             let infoPlist = Project.demoInfoPlist
+            let entitlementsPath = "App.entitlements"
             
             let target = Target.target(
                 name: name,
@@ -56,7 +57,7 @@ public extension Project {
                 infoPlist: .extendingDefault(with: infoPlist),
                 sources: ["Sources/**/*.swift"],
                 resources: [.glob(pattern: "Resources/**", excluding: [])],
-                entitlements: nil,
+                entitlements: .init("App.entitlements"),
                 scripts: [.SwiftLintString],
                 dependencies: [
                     internalDependencies,


### PR DESCRIPTION
## 🎫 지라 티켓 이슈
- DMVM-141
<br>

<br>

## 🛠️ 작업 내용
<!-- 작업 내용 (스크린샷도 같이 있으면 좋아요) -->
**유저가 로그인시 몽글 로그인 API를 사용하여 몽글의 accessToken, refreshToken을 발급합니다.**
## 카카오톡 로그인시
### 문제점
TCA 패턴 `Effect`에서 카카오톡 함수를 사용할 경우 sync문제가 발생.
문제는 아래와 같습니다.
- 비동기 작업 처리:
  - TCA에서 비동기 작업을 처리하기 위해서는 Effect를 사용해야 하지만, 카카오 SDK의 비동기 메서드를 Effect로 래핑하는 것이 어려웠습니다. 이는 SDK 메서드가 자체적으로 비동기 클로저를 사용하고 있어, TCA의 Effect와 직접적으로 연결하기 어렵기 때문입니다.
- 메인 스레드 이슈:
  - 일부 작업은 반드시 메인 스레드에서 실행되어야 합니다. 예를 들어, 특정 인증 관련 작업은 메인 스레드에서 실행되어야 하지만, 비동기 클로저 내에서 이를 보장하기 어려웠습니다.
 
## 애플 로그인시
TCA 패턴을 사용하여 애플 로그인 버튼 클릭시 경우에 따라 login action과 login Error action이 실행됩니다.
### **`appleButtonTapped(ASAuthorizationAppleIDCredential)`**
Effect에 따라 에러가 있으면 sideEffect를 반환합니다. `.run`을 이용했습니다.
``` swift
            case let .appleButtonTapped(credientials):
                return .run { send in
                    await send(.login(credientials))
                } catch: { error, send in
                    await send(.loginError(error))
                }
```

### **` case login(ASAuthorizationAppleIDCredential)`**
애플에서 유저 정보를 가져와  NetworkManager.shared.sendUserData()를 사용하여 유저의 정보를 서버에 전송합니다. 
``` swift
            case let .login(credentials):
                state.customer.uuid = credentials.user
                
                if let familyName = credentials.fullName?.familyName, let givenName = credentials.fullName?.givenName {
                    state.customer.customerName = familyName + givenName
                } else {
                    state.customer.customerName = nil
                }
                
                state.customer.authProvider = "APPLE"
                
                NetworkManager.shared.sendUserData(customer: state.customer)
                
                return .none
```

### 구현방식
  - `ObservableObject`를 따르는 `KaKaoAuthCore` 클래스를 생성하여 로그인 API를 연동 하였습니다.
  - 로그인 API에 필요한 데이터를 가져오면 `NetworkManager.shared.sendUserData()`를 사용하여 유저 정보를 서버에 전송합니다.
  - 서버에서는 유저에 대한 `accessToken, refreshToken`등 여러 데이터를 JSON 형태로 보내줍니다.
  - `JsonDecoder.shared.decodeCustomer()` 함수를 사용하여 받아온 JSON을 디코딩하여 `Customer `객체에 저장합니다.


<br>

<br>

## 📱 작업 화면
<!-- img src "이부분에 gif파일 넣어주시면 됩니다" -->
|화면 이름|스크린샷|
|:--:|:--:|
|ViewName|<img src = "" width ="250">|

<br>

## 🗒️ Note (optional)
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
