### PR TITLE
DMVM-[197](feat): connect chat view & home view to the mainview for web-view test

### DIFF
--- a/Mongle/Projects/App/Sources/MainApp.swift
+++ b/Mongle/Projects/App/Sources/MainApp.swift
@@ -21,7 +21,7 @@ struct Mongle: App {
     
     var body: some Scene {
         WindowGroup {
-            LoginView()
+            MainView()
                 .environmentObject(kakaoAuth)
         }
     }

--- a/Mongle/Projects/App/Sources/MainView.swift
+++ b/Mongle/Projects/App/Sources/MainView.swift
@@ -6,12 +6,32 @@
 //  Copyright © 2024 Mongle-iOS. All rights reserved.
 //
 
+import Core
+import ChatFeature
+import OnBoardingFeature
+import HomeFeature
 import SwiftUI
 
 struct MainView: View {
+    @EnvironmentObject var kakaoAuth: KaKaoAuthCore
+    
     var body: some View {
-        VStack {
-            Text("MainAppView")
+        if (kakaoAuth.customer.accessToken != nil) {
+            TabView {
+                HomeView()
+                    .tabItem {
+                        Image(systemName: "house.fill")
+                        Text("Home")
+                    }
+                
+                ChatView()
+                    .tabItem {
+                        Image(systemName: "message.fill")
+                        Text("Chat")
+                    }
+            }
+        } else {
+            LoginView()
         }
     }
 }

--- a/Mongle/Projects/App/Sources/MainView.swift
+++ b/Mongle/Projects/App/Sources/MainView.swift
@@ -16,7 +16,7 @@ struct MainView: View {
     @EnvironmentObject var kakaoAuth: KaKaoAuthCore
     
     var body: some View {
-        if (kakaoAuth.customer.accessToken != nil) {
+        if kakaoAuth.customer.accessToken != nil {
             TabView {
                 HomeView()
                     .tabItem {

--- a/Mongle/Projects/Features/ChatFeature/Sources/ChatView.swift
+++ b/Mongle/Projects/Features/ChatFeature/Sources/ChatView.swift
@@ -1,0 +1,21 @@
+//
+//  ChatView.swift
+//  ChatFeature
+//
+//  Created by bulmang on 8/24/24.
+//  Copyright © 2024 Mongle-iOS. All rights reserved.
+//
+
+import SwiftUI
+
+public struct ChatView: View {
+    public init() {}
+    
+    public var body: some View {
+        ChatWebView()
+    }
+}
+
+#Preview {
+    ChatView()
+}

--- a/Mongle/Projects/Features/ChatFeature/Sources/ChatWebView.swift
+++ b/Mongle/Projects/Features/ChatFeature/Sources/ChatWebView.swift
@@ -1,0 +1,92 @@
+//
+//  MapWebView.swift
+//  ProfileFeature
+//
+//  Created by bulmang on 7/14/24.
+//  Copyright © 2024 Mongle-iOS. All rights reserved.
+//
+
+import Core
+import SwiftUI
+import Ui
+import WebKit
+
+struct ChatWebView: View {
+    @EnvironmentObject var kakaoAuth: KaKaoAuthCore
+    
+    @State private var webUiView: ChatWebUiView?
+    
+    var body: some View {
+        VStack {
+            if let webUiView = webUiView {
+                webUiView
+                    .ignoresSafeArea()
+            } else {
+                ProgressView()
+            }
+        }
+        .onAppear {
+            let request = URLRequest(url: URL(string: Web.url(for: "chat-list"))!)
+            self.webUiView = ChatWebUiView(request: request, kakaoAuthCore: kakaoAuth)
+        }
+    }
+}
+
+class ContentController: NSObject, WKScriptMessageHandler, WKNavigationDelegate {
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) { }
+    
+    var kakaoAuthCore: KaKaoAuthCore
+
+    init(kakaoAuthCore: KaKaoAuthCore) {
+        self.kakaoAuthCore = kakaoAuthCore
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        guard let token = kakaoAuthCore.customer.accessToken, let uuid = kakaoAuthCore.customer.uuid else {
+            return
+        }
+
+        webView.evaluateJavaScript("handleIosWebviewToken('\(token), \(uuid)')") { result, error in
+            if let error = error {
+                print("Error \(error.localizedDescription)")
+                return
+            }
+
+            if let result = result {
+                print("Received Data \(result)")
+            } else {
+                print("No data received or it's void function")
+            }
+        }
+    }
+}
+
+struct ChatWebUiView: UIViewRepresentable {
+    let request: URLRequest
+    private var webView: WKWebView
+    private var contentController: ContentController
+
+    init(request: URLRequest, kakaoAuthCore: KaKaoAuthCore) {
+        let contentController = ContentController(kakaoAuthCore: kakaoAuthCore)
+        let config = WKWebViewConfiguration()
+        config.userContentController.add(contentController, name: "handleIosWebviewToken")
+
+        self.webView = WKWebView(frame: .zero, configuration: config)
+        self.request = request
+        self.contentController = contentController
+        self.webView.navigationDelegate = contentController
+    }
+
+    func makeUIView(context: Context) -> WKWebView {
+        webView
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {
+        uiView.load(request)
+    }
+}
+
+#Preview {
+    ChatWebView()
+        .environmentObject(KaKaoAuthCore())
+}

--- a/Mongle/Projects/Features/ChatFeature/Sources/ChatWebView.swift
+++ b/Mongle/Projects/Features/ChatFeature/Sources/ChatWebView.swift
@@ -14,20 +14,21 @@ import WebKit
 struct ChatWebView: View {
     @EnvironmentObject var kakaoAuth: KaKaoAuthCore
     
-    @State private var webUiView: ChatWebUiView?
+    @State private var webUIView: ChatWebUIView?
     
     var body: some View {
         VStack {
-            if let webUiView = webUiView {
+            if let webUiView = webUIView {
                 webUiView
                     .ignoresSafeArea()
             } else {
+                // TODO: 오류 표시 페이지 추가
                 ProgressView()
             }
         }
         .onAppear {
             let request = URLRequest(url: URL(string: Web.url(for: "chat-list"))!)
-            self.webUiView = ChatWebUiView(request: request, kakaoAuthCore: kakaoAuth)
+            self.webUIView = ChatWebUIView(request: request, kakaoAuthCore: kakaoAuth)
         }
     }
 }
@@ -42,7 +43,8 @@ class ContentController: NSObject, WKScriptMessageHandler, WKNavigationDelegate 
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        guard let token = kakaoAuthCore.customer.accessToken, let uuid = kakaoAuthCore.customer.uuid else {
+        guard let token = kakaoAuthCore.customer.accessToken, 
+                let uuid = kakaoAuthCore.customer.uuid else {
             return
         }
 
@@ -61,20 +63,23 @@ class ContentController: NSObject, WKScriptMessageHandler, WKNavigationDelegate 
     }
 }
 
-struct ChatWebUiView: UIViewRepresentable {
+struct ChatWebUIView: UIViewRepresentable {
     let request: URLRequest
     private var webView: WKWebView
     private var contentController: ContentController
 
     init(request: URLRequest, kakaoAuthCore: KaKaoAuthCore) {
-        let contentController = ContentController(kakaoAuthCore: kakaoAuthCore)
+        self.contentController = ContentController(kakaoAuthCore: kakaoAuthCore)
+        self.request = request
+        self.webView = ChatWebUIView.createWebView(contentController)
+    }
+    
+    private static func createWebView(_ contentController: ContentController) -> WKWebView {
         let config = WKWebViewConfiguration()
         config.userContentController.add(contentController, name: "handleIosWebviewToken")
-
-        self.webView = WKWebView(frame: .zero, configuration: config)
-        self.request = request
-        self.contentController = contentController
-        self.webView.navigationDelegate = contentController
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = contentController
+        return webView
     }
 
     func makeUIView(context: Context) -> WKWebView {

--- a/Mongle/Projects/Features/ChatFeature/Sources/Dummy.swift
+++ b/Mongle/Projects/Features/ChatFeature/Sources/Dummy.swift
@@ -1,9 +1,0 @@
-//
-//  Dummy.swift
-//  Core
-//
-//  Created by bulmang on 4/9/24.
-//  Copyright © 2024 Mongle-iOS. All rights reserved.
-//
-
-import Foundation


### PR DESCRIPTION
## 🎫 지라 티켓 이슈
DMVM-[197]
<br>

<br>

## 🛠️ 작업 내용
<!-- 작업 내용 (스크린샷도 같이 있으면 좋아요) -->
@VictoryJu 님께서 채팅 작업중에 **User**의 `UUID`와 `Token`값을 요청하셨습니다.
`handleIosWebviewToken`로 iOS와 React에서 이름을 맞춰 Web-View에서 `UUID`, `Token`데이터를 수신 받을 수 있도록 작업을 진행했습니다.

### func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!)
이 함수를 이용해서 Web-View 연결이 로드가 되면 곧 바로 데이터를 송신합니다.
`guard`문을 사용하여 `UUID`, `Token`를 언래핑합니다. 그 후 `WKWebView`class에 있는 `evaluateJavaScript`함수를 사용하여 데이터를 송신합니다.
```
func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
        guard let token = kakaoAuthCore.customer.accessToken, let uuid = kakaoAuthCore.customer.uuid else {
            return
        }

        webView.evaluateJavaScript("handleIosWebviewToken('\(token), \(uuid)')") { result, error in
            if let error = error {
                print("Error \(error.localizedDescription)")
                return
            }

            if let result = result {
                print("Received Data \(result)")
            } else {
                print("No data received or it's void function")
            }
        }
    }
```
<br>

<br>

## 📱 작업 화면
<!-- img src "이부분에 gif파일 넣어주시면 됩니다" -->
|화면 이름|스크린샷|
|:--:|:--:|
|ChatView(uuid, token 데이터 전송)|<img src = "https://github.com/user-attachments/assets/3b5992ab-7ba1-4b85-8189-c47025d3d888" width ="550">|

<br>

## 🗒️ Note (optional)
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
현재 LoginView에 TabView 이동은 kakaoAuth.customer.accessToken에 값이 들어오면 이동이 되지만 추후 리팩토링이 필요합니다.
네비게이션 구조 작업을 진행하면서 적용시키면 좋을 것 같습니다.

PR 승인이 된다면 테스트 플라이트에 배포하여 @VictoryJu 님께서 테스트 하시기 편하신 환경을 만들려고 합니다.